### PR TITLE
fix(sales,movimiento): stop using legacy field names, add E2E coverage

### DIFF
--- a/e2e/sales.spec.ts
+++ b/e2e/sales.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, Page } from '@playwright/test';
+import { clickAndWaitForApi } from './helpers/master-crud.helpers';
+
+// Venta no usa el patrón de modal compartido: es una página completa con tabs (Nueva Venta /
+// Historial), como Cotización y Compra. El form group (buildSaleForm) no tiene Validators.required
+// en ningún control -- el botón "Guardar Venta" solo se deshabilita si detailsArray está vacío --
+// así que la validación real de campos obligatorios vive 100% en el backend (StoreVentaRequest).
+
+async function selectViaSearchSelect(page: Page, placeholder: string, searchTerm: string) {
+  const input = page.locator(`input[placeholder="${placeholder}"]`);
+  await input.click();
+  await input.fill(searchTerm);
+  const option = page.locator('li[cdropdownitem]', { hasText: searchTerm }).first();
+  await expect(option).toBeVisible({ timeout: 10_000 });
+  await option.click();
+}
+
+async function fillVentaBase(page: Page) {
+  await page.goto('/ventas');
+
+  await page.locator('#emp_id').selectOption({ index: 1 });
+  await page.locator('#doc_id').selectOption({ index: 1 });
+  await page.locator('#suc_id').selectOption({ index: 1 });
+  await page.locator('#almacen_id').selectOption({ index: 1 });
+  await page.locator('#mon_id').selectOption({ index: 1 });
+  await page.locator('#vendedor_id').fill('1');
+
+  await selectViaSearchSelect(page, 'Buscar cliente...', 'Hearly');
+}
+
+async function addProducto(page: Page, searchTerm: string) {
+  await selectViaSearchSelect(page, 'Buscar producto...', searchTerm);
+  await page.getByRole('button', { name: 'Agregar', exact: true }).click();
+  await expect(page.locator('input[formcontrolname="cantidad"]').first()).toBeVisible();
+  // Si el producto trae precio_venta_base seedeado, el campo llega ya deshabilitado con ese
+  // valor. Si no, hay que tipearlo a mano (mismo patrón que purchase.spec.ts con costo_unitario).
+  const precioInput = page.locator('input[formcontrolname="precio_unitario"]').first();
+  if (await precioInput.isEnabled()) {
+    await precioInput.fill('50');
+  }
+}
+
+test('Venta: crear standalone con afecta stock, listar y ver en Historial', async ({ page }) => {
+  await fillVentaBase(page);
+  // Contado/Efectivo autocompletan la venta al emitirla (mismo patrón que Compra) -- se elige
+  // explícitamente para poder afirmar el estado resultante, en vez de depender del default.
+  await page.locator('#mp_cod').selectOption({ label: 'CONTADO' });
+  // afecta_stock ya nace tildado (buildSaleForm default true) -- se deja así a propósito: es
+  // justo el camino que hoy registra el movimiento Kardex de SALIDA (feature de esta sesión).
+  await expect(page.locator('#afecta_stock')).toBeChecked();
+
+  await addProducto(page, 'Arroz');
+
+  const createBody = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Venta' }).click(),
+  )) as { isValid: boolean; data: { venta_id: number; numero_completo: string; estado_id: number } };
+  expect(createBody.isValid, JSON.stringify(createBody)).toBe(true);
+  expect(createBody.data.estado_id, 'contado debe autocompletar la venta').toBe(2);
+
+  const numeroCompleto = createBody.data.numero_completo;
+  expect(numeroCompleto, 'numero_completo debería haberse generado').toBeTruthy();
+
+  // save() cambia a Historial y vuelve a buscar -- se espera esa transición en vez del click.
+  await expect(page.locator('a.nav-link', { hasText: 'Historial' })).toHaveClass(/active/, {
+    timeout: 10_000,
+  });
+
+  const row = page.locator('table tbody tr', { hasText: numeroCompleto });
+  await expect(row).toBeVisible({ timeout: 10_000 });
+});
+
+test('Venta a crédito nace Pendiente (no autocompleta)', async ({ page }) => {
+  await fillVentaBase(page);
+  await page.locator('#mp_cod').selectOption({ label: 'CREDITO' });
+
+  await addProducto(page, 'Arroz');
+
+  const createBody = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Venta' }).click(),
+  )) as { isValid: boolean; data: { estado_id: number } };
+  expect(createBody.isValid, JSON.stringify(createBody)).toBe(true);
+  expect(createBody.data.estado_id, 'crédito debe nacer Pendiente').toBe(1);
+});
+
+test('Venta vinculada a una Cotización existente la pasa a Facturado', async ({ page }) => {
+  // ---- Fixture: crear la cotización primero (mismo flujo que quotation.spec.ts) ----
+  await page.goto('/cotizaciones');
+
+  function fieldByLabel(label: string) {
+    return page
+      .locator(`label:text-is("${label}")`)
+      .locator('xpath=following-sibling::*[self::input or self::select or self::textarea][1]')
+      .first();
+  }
+
+  await fieldByLabel('Sucursal').selectOption({ index: 1 });
+  await fieldByLabel('Moneda').selectOption({ index: 1 });
+  await fieldByLabel('Tipo de Pago').selectOption({ index: 1 });
+  // Cotización usa placeholders distintos a Venta ('Cliente'/'Producto', no 'Buscar cliente...').
+  await selectViaSearchSelect(page, 'Cliente', 'Hearly');
+  await selectViaSearchSelect(page, 'Producto', 'Arroz');
+  await page.getByRole('button', { name: 'Agregar Producto', exact: true }).click();
+  await expect(page.locator('input[formcontrolname="cantidad"]').first()).toBeVisible();
+
+  const cotizacionBody = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Cotización' }).click(),
+  )) as { isValid: boolean; data: { id: number; numero_completo: string } };
+  expect(cotizacionBody.isValid, JSON.stringify(cotizacionBody)).toBe(true);
+  const cotizacionNumero = cotizacionBody.data.numero_completo;
+
+  // ---- Venta vinculada a esa cotización ----
+  // El modal de búsqueda no es una tabla: son tarjetas .document-item con filtrado en vivo
+  // (input) -> filteredItems(), sin botón "Buscar" propio.
+  await page.goto('/ventas');
+  await page.getByRole('button', { name: 'Buscar cotización' }).click();
+  await page.locator('input[placeholder="Buscar por número o cliente..."]').fill(cotizacionNumero);
+  const cotOption = page.locator('.document-item', { hasText: cotizacionNumero }).first();
+  await expect(cotOption).toBeVisible({ timeout: 10_000 });
+  await cotOption.click();
+
+  // Vincular auto-completa cliente (readonly) -- solo faltan los campos que no vienen del documento.
+  await expect(page.locator('span.fw-semibold', { hasText: cotizacionNumero })).toBeVisible();
+  await page.locator('#emp_id').selectOption({ index: 1 });
+  await page.locator('#doc_id').selectOption({ index: 1 });
+  await page.locator('#suc_id').selectOption({ index: 1 });
+  await page.locator('#almacen_id').selectOption({ index: 1 });
+  await page.locator('#mon_id').selectOption({ index: 1 });
+  await page.locator('#mp_cod').selectOption({ label: 'CONTADO' });
+  await page.locator('#vendedor_id').fill('1');
+
+  await addProducto(page, 'Arroz');
+
+  const ventaBody = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Venta' }).click(),
+  )) as { isValid: boolean; data: { venta_id: number } };
+  expect(ventaBody.isValid, JSON.stringify(ventaBody)).toBe(true);
+
+  // ---- Confirmar que la Cotización pasó a Facturado ----
+  // Navegación fresca aterriza en "Nueva Cotización" (tab por defecto), no en Historial.
+  await page.goto('/cotizaciones');
+  await page.locator('a.nav-link', { hasText: 'Historial' }).click();
+  // Busca por numero_completo (no 'Hearly') -- el backend matchea nombre contra
+  // numero_completo OR cliente.nombre, y con muchas corridas acumuladas en esta DB
+  // persistente, 'Hearly' devuelve más filas de las que la primera página muestra.
+  // numero_completo es único por corrida, así que garantiza una sola fila.
+  await page.locator('[formcontrolname="nombre"]').fill(cotizacionNumero);
+  // El filtro por defecto solo trae Pendiente (01) -- hay que tildar Facturado (02) para verla,
+  // mismo patrón que quotation.spec.ts usa con Anulado (03).
+  await page.locator('#state_02').check();
+  await page.getByRole('button', { name: 'Buscar', exact: true }).click();
+
+  const cotRow = page.locator('table tbody tr', { hasText: cotizacionNumero });
+  await expect(cotRow).toBeVisible({ timeout: 10_000 });
+  await expect(cotRow).toContainText('Facturado');
+});

--- a/e2e/traslado.spec.ts
+++ b/e2e/traslado.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, Page } from '@playwright/test';
+import { clickAndWaitForApi } from './helpers/master-crud.helpers';
+
+// Movimientos (Ingreso/Salida/Transferencia) usa binding dinámico [formControlName]="field...",
+// que nunca refleja un atributo formcontrolname real -- mismo motivo por el que Cotización y
+// Compra resuelven sus campos por label visible en vez de por atributo (ver master-crud.helpers).
+function fieldByLabel(page: Page, label: string) {
+  return page
+    .locator(`label:text-is("${label}")`)
+    .locator('xpath=following-sibling::*[self::input or self::select][1]')
+    .first();
+}
+
+async function selectViaSearchSelect(page: Page, placeholder: string, searchTerm: string) {
+  const input = page.locator(`input[placeholder="${placeholder}"]`);
+  await input.click();
+  await input.fill(searchTerm);
+  const option = page.locator('li[cdropdownitem]', { hasText: searchTerm }).first();
+  await expect(option).toBeVisible({ timeout: 10_000 });
+  await option.click();
+}
+
+/**
+ * Registra un Ingreso real para el producto en el almacén dado -- necesario porque Traslados
+ * valida stock contra el ledger de Kardex (inventario_movimientos), no contra producto_almacen.
+ * El stock cargado por otras vías (seed inicial) no cuenta para esa validación; sin este paso,
+ * cualquier transferencia falla con "Stock insuficiente. Disponible: 0" aunque el saldo real
+ * mostrado en la UI de Almacén sea positivo.
+ */
+async function registrarIngreso(page: Page, almacenLabel: string, productoTerm: string, cantidad: number) {
+  await page.goto('/movimientos');
+  await fieldByLabel(page, 'Tipo de Movimiento').selectOption({ label: 'Ingreso' });
+  await fieldByLabel(page, 'Almacén').selectOption({ label: almacenLabel });
+  await selectViaSearchSelect(page, 'Buscar producto...', productoTerm);
+  await page.getByRole('button', { name: 'Agregar', exact: true }).click();
+
+  const cantidadInput = page.locator('input[formcontrolname="cantidad"]').first();
+  await expect(cantidadInput).toBeVisible();
+  await cantidadInput.fill(String(cantidad));
+  // El seed no trae precio_compra_base en ningún producto -- costoUnitario se tipea a mano.
+  await page.locator('input[formcontrolname="costoUnitario"]').first().fill('5.5');
+
+  const body = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Movimiento' }).click(),
+  )) as { isValid: boolean };
+  expect(body.isValid, JSON.stringify(body)).toBe(true);
+}
+
+test('Traslado: transferir entre almacenes descuenta origen y suma destino', async ({ page }) => {
+  // ALMACEN PRINCIPAL / SECUNDARIO son fixtures reales de esta DB de dev (ver AlmacenApiTest /
+  // seed real), Fideos es un producto seed real usado en purchase.spec.ts también.
+  const cantidad = 5 + (Date.now() % 20); // único por corrida, sin depender de orden de ejecución
+
+  await registrarIngreso(page, 'ALMACEN PRINCIPAL', 'Fideos', cantidad);
+
+  await page.goto('/movimientos');
+  await fieldByLabel(page, 'Tipo de Movimiento').selectOption({ label: 'Transferencia' });
+  await fieldByLabel(page, 'Almacén Origen').selectOption({ label: 'ALMACEN PRINCIPAL' });
+  await fieldByLabel(page, 'Almacén Destino').selectOption({ label: 'ALMACEN SECUNDARIO' });
+  await selectViaSearchSelect(page, 'Buscar producto...', 'Fideos');
+  await page.getByRole('button', { name: 'Agregar', exact: true }).click();
+
+  const cantidadInput = page.locator('input[formcontrolname="cantidad"]').first();
+  await expect(cantidadInput).toBeVisible();
+  await cantidadInput.fill(String(cantidad));
+  await page.locator('input[formcontrolname="costoUnitario"]').first().fill('5.5');
+
+  const body = (await clickAndWaitForApi(page, ['POST'], () =>
+    page.getByRole('button', { name: 'Guardar Movimiento' }).click(),
+  )) as { isValid: boolean; data: { total_documentos: number } };
+  expect(body.isValid, JSON.stringify(body)).toBe(true);
+  expect(body.data.total_documentos, 'una transferencia genera 2 documentos (salida + ingreso)').toBe(2);
+
+  // ---- Confirmar en Historial ----
+  // Cambiar de tab no dispara la búsqueda sola -- hay que pedirla explícitamente.
+  await page.locator('a.nav-link', { hasText: 'Historial' }).click();
+  await page.getByRole('button', { name: 'Buscar', exact: true }).click();
+  const rows = page.locator('table tbody tr', { hasText: 'Transferencia' });
+  await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+});
+
+test('Traslado: stock insuficiente en origen se bloquea con mensaje claro', async ({ page }) => {
+  await page.goto('/movimientos');
+  await fieldByLabel(page, 'Tipo de Movimiento').selectOption({ label: 'Transferencia' });
+  await fieldByLabel(page, 'Almacén Origen').selectOption({ label: 'ALMACEN EN TRANSITO' });
+  await fieldByLabel(page, 'Almacén Destino').selectOption({ label: 'ALMACEN PRINCIPAL' });
+  // ALMACEN EN TRANSITO no tiene ingresos reales registrados en Kardex para este producto --
+  // cualquier cantidad > 0 debería rechazarse.
+  await selectViaSearchSelect(page, 'Buscar producto...', 'Fideos');
+  await page.getByRole('button', { name: 'Agregar', exact: true }).click();
+
+  const cantidadInput = page.locator('input[formcontrolname="cantidad"]').first();
+  await expect(cantidadInput).toBeVisible();
+  await cantidadInput.fill('999999');
+  await page.locator('input[formcontrolname="costoUnitario"]').first().fill('5.5');
+
+  const [response] = await Promise.all([
+    page.waitForResponse((res) => res.request().method() === 'POST' && res.url().includes('/movimientos-documentos')),
+    page.getByRole('button', { name: 'Guardar Movimiento' }).click(),
+  ]);
+  expect(response.status(), 'stock insuficiente debe ser 422, no 500').toBe(422);
+  const body = await response.json();
+  expect(body.isValid).toBe(false);
+  expect(body.messages[0].message).toContain('Stock insuficiente');
+});
+
+test('Traslado: mismo almacén de origen y destino se bloquea en el frontend', async ({ page }) => {
+  await page.goto('/movimientos');
+  await fieldByLabel(page, 'Tipo de Movimiento').selectOption({ label: 'Transferencia' });
+  await fieldByLabel(page, 'Almacén Origen').selectOption({ label: 'ALMACEN PRINCIPAL' });
+  await fieldByLabel(page, 'Almacén Destino').selectOption({ label: 'ALMACEN PRINCIPAL' });
+
+  await expect(page.locator('.is-invalid')).toHaveCount(0); // no dispara hasta touched/submit
+  await selectViaSearchSelect(page, 'Buscar producto...', 'Fideos');
+  await page.getByRole('button', { name: 'Agregar', exact: true }).click();
+  await page.locator('input[formcontrolname="cantidad"]').first().fill('1');
+  await page.getByRole('button', { name: 'Guardar Movimiento' }).click();
+
+  // El form es inválido (validador de almacenes distintos) -- no debe llegar a disparar el POST.
+  await expect(page.locator('a.nav-link', { hasText: 'Historial' })).not.toHaveClass(/active/);
+});

--- a/src/app/movimiento/components/movimiento-detail-table.component.ts
+++ b/src/app/movimiento/components/movimiento-detail-table.component.ts
@@ -51,6 +51,7 @@ import { MovimientoDetailForm } from '../core/types/movement-detail-form';
               <th style="width: 25%">Codigo</th>
               <th style="width: 50%">Producto</th>
               <th style="width: 15%">Cantidad</th>
+              <th style="width: 15%">Costo Unitario</th>
               @if (showActions) {
               <th style="width: 5%"></th>
               }
@@ -59,7 +60,7 @@ import { MovimientoDetailForm } from '../core/types/movement-detail-form';
           <tbody>
             @if (detailsArray.length === 0) {
             <tr>
-              <td colspan="5" class="text-center text-muted py-4">No hay productos agregados</td>
+              <td colspan="6" class="text-center text-muted py-4">No hay productos agregados</td>
             </tr>
             } @for (detail of detailsArray.controls; track $index) {
             <tr [formGroup]="detail">
@@ -75,6 +76,15 @@ import { MovimientoDetailForm } from '../core/types/movement-detail-form';
                   type="number"
                   class="form-control form-control-sm"
                   formControlName="cantidad"
+                  min="0.0001"
+                  step="0.0001"
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  class="form-control form-control-sm"
+                  formControlName="costoUnitario"
                   min="0.0001"
                   step="0.0001"
                 />

--- a/src/app/movimiento/core/models/get-movimiento.model.ts
+++ b/src/app/movimiento/core/models/get-movimiento.model.ts
@@ -1,5 +1,5 @@
 import { MovimientoModel } from "./movimiento.model";
 
 export interface GetMovimientoModel extends MovimientoModel {
-    doc_id: number;
+    id: number;
 }

--- a/src/app/movimiento/core/models/movimiento.model.ts
+++ b/src/app/movimiento/core/models/movimiento.model.ts
@@ -1,8 +1,8 @@
 import { GetAlmacenModel } from 'src/app/almacen/core/models';
 export class MovimientoModel {
   almacen_origen?: GetAlmacenModel;
-  doc_numero_completo?: string;
-  doc_fecha_emision?: Date;
-  doc_tipo_movimiento?: string;
+  numero_completo?: string;
+  fecha_emision?: Date;
+  tipo_movimiento?: string;
   usuario_nombre?: string;
 }

--- a/src/app/movimiento/helpers/movement-sort.ts
+++ b/src/app/movimiento/helpers/movement-sort.ts
@@ -1,3 +1,3 @@
 export function movementFilterSort() {
-  return [{ property: 'doc_fecha_emision', direction: 'desc' }];
+  return [{ property: 'fecha_emision', direction: 'desc' }];
 }

--- a/src/app/movimiento/pages/movimiento-main/movimiento-main.page.html
+++ b/src/app/movimiento/pages/movimiento-main/movimiento-main.page.html
@@ -110,8 +110,8 @@
                     <label for="temp_prod_id" class="form-label">Producto</label>
                     <app-search-select
                       placeholder="Buscar producto..."
-                      bindLabel="prod_nom"
-                      bindValue="prod_id"
+                      bindLabel="label"
+                      bindValue="id"
                       [serviceFn]="getProductSearchFn()"
                       [showError]="almacenError()"
                       [errorMessage]="almacenError() ? 'Seleccione un almacén primero' : ''"
@@ -238,7 +238,7 @@
                         </thead>
                         <tbody>
                           @if (movimientos.length > 0) {
-                            @for (item of movimientos; track item.doc_id) {
+                            @for (item of movimientos; track item.id) {
                               <tr>
                                 <td>
                                   <button
@@ -246,26 +246,26 @@
                                     class="me-2"
                                     cButton
                                     color="secondary"
-                                    (click)="onPrint(item.doc_id, item.doc_numero_completo)"
+                                    (click)="onPrint(item.id, item.numero_completo)"
                                   >
                                     <svg cIcon name="cilPrint"></svg>
                                   </button>
                                 </td>
-                                <td>{{ item.doc_numero_completo }}</td>
+                                <td>{{ item.numero_completo }}</td>
                                 <td>{{ item.almacen_origen?.nombre || '-' }}</td>
-                                <td>{{ item.doc_fecha_emision | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+                                <td>{{ item.fecha_emision | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
                                 <td>
                                   <span
                                     class="badge"
                                     [ngClass]="{
                                       'bg-info':
-                                        item.doc_tipo_movimiento === 'Transferencia Salida' ||
-                                        item.doc_tipo_movimiento === 'Transferencia Ingreso',
-                                      'bg-success': item.doc_tipo_movimiento === 'Ingreso',
-                                      'bg-danger': item.doc_tipo_movimiento === 'Salida',
+                                        item.tipo_movimiento === 'Transferencia Salida' ||
+                                        item.tipo_movimiento === 'Transferencia Ingreso',
+                                      'bg-success': item.tipo_movimiento === 'Ingreso',
+                                      'bg-danger': item.tipo_movimiento === 'Salida',
                                     }"
                                   >
-                                    {{ item.doc_tipo_movimiento }}
+                                    {{ item.tipo_movimiento }}
                                   </span>
                                 </td>
                                 <td>{{ item.usuario_nombre }}</td>

--- a/src/app/movimiento/pages/movimiento-main/movimiento-main.page.ts
+++ b/src/app/movimiento/pages/movimiento-main/movimiento-main.page.ts
@@ -273,7 +273,7 @@ export class MovimientoMainPage extends BaseSearchComponent implements OnInit {
     }
 
     const exists = this.detailsArray.controls.some(
-      (c) => c.get('idProducto')?.value === this.selectedProduct?.prod_id,
+      (c) => c.get('idProducto')?.value === this.selectedProduct?.id,
     );
     if (exists) {
       this.#globalNotification.openToastAlert(
@@ -285,10 +285,10 @@ export class MovimientoMainPage extends BaseSearchComponent implements OnInit {
     }
 
     const detailGroup = this.#formBuilder.group({
-      idProducto: [this.selectedProduct.prod_id, Validators.required],
+      idProducto: [this.selectedProduct.id, Validators.required],
       cantidad: [1, [Validators.required, Validators.min(0.0001)]],
-      nombreProducto: [this.selectedProduct.prod_nom],
-      codigoProducto: [this.selectedProduct.prod_cod],
+      nombreProducto: [this.selectedProduct.nombre],
+      codigoProducto: [this.selectedProduct.codigo],
       costoUnitario: [this.selectedProduct.pcompra],
     });
 

--- a/src/app/sales/pages/sales-main/sales-main.page.html
+++ b/src/app/sales/pages/sales-main/sales-main.page.html
@@ -262,8 +262,8 @@
                       <label for="cli_id" class="form-label">Buscar Cliente</label>
                       <app-search-select
                         [placeholder]="'Buscar cliente...'"
-                        [bindLabel]="'cli_nom'"
-                        [bindValue]="'cli_id'"
+                        [bindLabel]="'businessName'"
+                        [bindValue]="'id'"
                         [serviceFn]="serviceMap['customerSearch']"
                         [disabled]="isClientReadonly()"
                         [initialValue]="getClientInitialValue('cli_id')"
@@ -312,8 +312,8 @@
                       <label for="prod_id" class="form-label">Producto</label>
                       <app-search-select
                         [placeholder]="'Buscar producto...'"
-                        [bindLabel]="'prod_nom'"
-                        [bindValue]="'prod_id'"
+                        [bindLabel]="'label'"
+                        [bindValue]="'id'"
                         [serviceFn]="serviceMap['productSearch']"
                         [disabled]="!form.get('suc_id')?.value"
                         (itemSelected)="onSelectItem('prod_id', $event)"

--- a/src/app/sales/pages/sales-main/sales-main.page.ts
+++ b/src/app/sales/pages/sales-main/sales-main.page.ts
@@ -190,7 +190,7 @@ export class SalesMainPage extends BaseSearchComponent implements OnInit {
   }
 
   serviceMap: Record<string, (term: string) => any> = {
-    customerSearch: (term: string) => this.#customerService.getAll(),
+    customerSearch: (term: string) => this.#customerService.searchQuick(term),
     productSearch: (term: string) =>
       this.#productService.searchQuick({
         term,
@@ -200,11 +200,11 @@ export class SalesMainPage extends BaseSearchComponent implements OnInit {
 
   patchCustomer(item: any) {
     this.form.patchValue({
-      cli_documento: item.cli_documento,
-      tip_id: item.tip_id,
-      cli_direcc: item.cli_direcc,
-      cli_correo: item.cli_correo,
-      cli_telf: item.cli_telf,
+      cli_documento: item.documento,
+      tip_id: item.tipoDocumentoId,
+      cli_direcc: item.direccion,
+      cli_correo: item.email,
+      cli_telf: item.telefono,
     });
   }
 
@@ -328,9 +328,15 @@ export class SalesMainPage extends BaseSearchComponent implements OnInit {
 
     if (formControlName === 'prod_id') {
       this.form.patchValue({
-        prod_id: item.prod_id,
+        prod_id: item.id,
       });
       this.selectedProduct = item;
+      return;
+    }
+
+    if (formControlName === 'cli_id') {
+      this.form.get('cli_id')?.setValue(item.id);
+      this.patchCustomer(item);
       return;
     }
 
@@ -338,17 +344,13 @@ export class SalesMainPage extends BaseSearchComponent implements OnInit {
     if (control) {
       control.setValue(item[formControlName]);
     }
-
-    if (formControlName === 'cli_id') {
-      this.patchCustomer(item);
-    }
   }
 
   addProductToDetail() {
     if (!this.selectedProduct) return;
 
     const exists = this.detailsArray.controls.some(
-      (control) => control.value.prod_id === this.selectedProduct.prod_id,
+      (control) => control.value.prod_id === this.selectedProduct.id,
     );
 
     if (exists) {
@@ -361,10 +363,10 @@ export class SalesMainPage extends BaseSearchComponent implements OnInit {
     }
 
     const detailForm = this.#formBuilder.group({
-      prod_id: [this.selectedProduct.prod_id],
+      prod_id: [this.selectedProduct.id],
       cantidad: [1],
-      prod_nom: [{ value: this.selectedProduct.prod_nom, disabled: true }],
-      prod_cod_interno: [this.selectedProduct.prod_cod],
+      prod_nom: [{ value: this.selectedProduct.nombre, disabled: true }],
+      prod_cod_interno: [this.selectedProduct.codigo],
       unidad: [this.selectedProduct.unidad],
       precio_unitario: [{ value: this.selectedProduct.pventa ?? null }],
       precio_venta: [{ value: null, disabled: true }],


### PR DESCRIPTION
Sales customer search called getAll() instead of searchQuick(term), so typing never actually filtered results. Both Sales and Movimiento pages also read legacy response keys (prod_nom, prod_id, cli_documento, etc.) that don't exist on the real DTO/mapper output (id, nombre, documento, ...), same class of camelCase/snake_case drift already flagged for the other master modules. Customer linking in Sales effectively never worked end to end.

Adds e2e/sales.spec.ts and e2e/traslado.spec.ts, following the existing purchase.spec.ts/quotation.spec.ts conventions, covering the two flows wired up on the backend today (Kardex movement recording on Venta/ Compra, and warehouse-to-warehouse transfers). Scopes the quotation lookup in the linked-sale test by numero_completo instead of a broad customer-name filter, since the shared dev DB accumulates rows across runs and a name-only filter can fall off the first page of results.