### PR TITLE
fix(products,almacen): add missing weight field, fix null-crash mappe…

### DIFF
--- a/src/app/almacen/core/dtos/almacen.dto.ts
+++ b/src/app/almacen/core/dtos/almacen.dto.ts
@@ -21,7 +21,10 @@ export type AlmacenDto = {
 };
 
 export type CreateAlmacenDto = {
-  suc_id: number;
+  // AlmacenController::store() valida "sucursal_id" (fix de hoy: la validación vieja pedía
+  // suc_id contra una columna que sucursales nunca tuvo). No confundir con el "suc_id" que
+  // ese mismo endpoint devuelve en la respuesta -- ver el comentario en AlmacenDto arriba.
+  sucursal_id: number;
   codigo: string;
   nombre: string;
   descripcion?: string | null;

--- a/src/app/almacen/core/mappers/almacen.mapper.ts
+++ b/src/app/almacen/core/mappers/almacen.mapper.ts
@@ -29,7 +29,7 @@ export class AlmacenMapper {
 
   toApiCreate(model: CreateAlmacenModel): CreateAlmacenDto {
     return {
-      suc_id: model.sucursalId,
+      sucursal_id: model.sucursalId,
       codigo: model.codigo,
       nombre: model.nombre,
       descripcion: model.descripcion,

--- a/src/app/products/components/product-new-edit-modal/product-new-edit-modal.html
+++ b/src/app/products/components/product-new-edit-modal/product-new-edit-modal.html
@@ -19,6 +19,10 @@
                     [name]="item.label"
                     [id]="item.formControlName + 'id'"
                     [formControlName]="item.formControlName"
+                    [class.is-invalid]="
+                      form.get(item.formControlName)?.invalid &&
+                      form.get(item.formControlName)?.touched
+                    "
                   >
                     <option [ngValue]="null">Seleccione</option>
                     @for (dataItem of item.options; track $index) {
@@ -27,6 +31,11 @@
                       </option>
                     }
                   </select>
+                  <app-validation-messages
+                    [controlName]="item.formControlName"
+                    [form]="form"
+                    [messages]="errorMessages"
+                  ></app-validation-messages>
                 }
                 @case ('file') {
                   <div class="d-flex flex-column align-items-start gap-2">
@@ -94,7 +103,16 @@
                     min="0"
                     step="0.01"
                     [formControlName]="item.formControlName"
+                    [class.is-invalid]="
+                      form.get(item.formControlName)?.invalid &&
+                      form.get(item.formControlName)?.touched
+                    "
                   />
+                  <app-validation-messages
+                    [controlName]="item.formControlName"
+                    [form]="form"
+                    [messages]="errorMessages"
+                  ></app-validation-messages>
                 }
                 @default {
                   <input
@@ -103,7 +121,16 @@
                     name=""
                     id=""
                     [formControlName]="item.formControlName"
+                    [class.is-invalid]="
+                      form.get(item.formControlName)?.invalid &&
+                      form.get(item.formControlName)?.touched
+                    "
                   />
+                  <app-validation-messages
+                    [controlName]="item.formControlName"
+                    [form]="form"
+                    [messages]="errorMessages"
+                  ></app-validation-messages>
                 }
               }
             </c-col>

--- a/src/app/products/components/product-new-edit-modal/product-new-edit-modal.ts
+++ b/src/app/products/components/product-new-edit-modal/product-new-edit-modal.ts
@@ -13,7 +13,8 @@ import {
 import { ProductService } from '../../core/services/product.service';
 import { CreateProduct, UpdateProduct, Product } from '../../core/models';
 import { IconDirective } from '@coreui/icons-angular';
-import { buildProductForm, productStructure } from '../../helpers';
+import { buildProductForm, productStructure, messages } from '../../helpers';
+import { ValidationMessagesComponent } from '@shared/components/error-messages/validation-messages.component';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { BaseComponent } from '../../../shared/base/base.component';
 import { MODULES } from '../../../core/config/permissions/modules';
@@ -41,6 +42,7 @@ import { CommonModule } from '@angular/common';
     ModalFooterComponent,
     ReactiveFormsModule,
     SpinnerComponent,
+    ValidationMessagesComponent,
   ],
   templateUrl: './product-new-edit-modal.html',
   styleUrl: './product-new-edit-modal.scss',
@@ -49,6 +51,7 @@ export class ProductNewEditModal extends BaseComponent implements OnInit {
   form!: FormGroup;
   visible = false;
   structure = productStructure();
+  errorMessages = messages;
   selectedFile: File | null = null;
   imagePreview = signal<string | null>(null);
   isCompressing = signal<boolean>(false);

--- a/src/app/products/core/mappers/product.mapper.ts
+++ b/src/app/products/core/mappers/product.mapper.ts
@@ -94,18 +94,18 @@ export class ProductMapper {
   static toFormDataCreate(model: CreateProduct, imageFile?: File): FormData {
     const formData = new FormData();
 
-    formData.append('categoria_id', model.categoryId.toString());
-    formData.append('marca_id', model.brandId.toString());
+    ProductMapper.appendIfPresent(formData, 'categoria_id', model.categoryId);
+    ProductMapper.appendIfPresent(formData, 'marca_id', model.brandId);
     formData.append('nombre', model.name);
-    formData.append('descripcion', model.description);
-    formData.append('unidad_id', model.unitId.toString());
-    formData.append('codigo_interno', model.internalCode);
-    formData.append('codigo_fabricante', model.manufacturerCode);
-    formData.append('peso', model.weight.toString());
-    formData.append('sucursal_id', model.branchId.toString());
-    formData.append('moneda_id', model.currencyId.toString());
-    formData.append('precio_compra_base', model.basePurchasePrice.toString());
-    formData.append('precio_venta_base', model.baseSalePrice.toString());
+    ProductMapper.appendIfPresent(formData, 'descripcion', model.description);
+    ProductMapper.appendIfPresent(formData, 'unidad_id', model.unitId);
+    ProductMapper.appendIfPresent(formData, 'codigo_interno', model.internalCode);
+    ProductMapper.appendIfPresent(formData, 'codigo_fabricante', model.manufacturerCode);
+    ProductMapper.appendIfPresent(formData, 'peso', model.weight);
+    ProductMapper.appendIfPresent(formData, 'sucursal_id', model.branchId);
+    ProductMapper.appendIfPresent(formData, 'moneda_id', model.currencyId);
+    ProductMapper.appendIfPresent(formData, 'precio_compra_base', model.basePurchasePrice);
+    ProductMapper.appendIfPresent(formData, 'precio_venta_base', model.baseSalePrice);
 
     if (model.branches && model.branches.length > 0) {
       model.branches.forEach((branch, index) => {
@@ -128,18 +128,18 @@ export class ProductMapper {
     const formData = new FormData();
 
     formData.append('id', model.id.toString());
-    formData.append('categoria_id', model.categoryId.toString());
-    formData.append('marca_id', model.brandId.toString());
+    ProductMapper.appendIfPresent(formData, 'categoria_id', model.categoryId);
+    ProductMapper.appendIfPresent(formData, 'marca_id', model.brandId);
     formData.append('nombre', model.name);
-    formData.append('descripcion', model.description);
-    formData.append('unidad_id', model.unitId.toString());
-    formData.append('codigo_interno', model.internalCode);
-    formData.append('codigo_fabricante', model.manufacturerCode);
-    formData.append('peso', model.weight.toString());
-    formData.append('sucursal_id', model.branchId.toString());
-    formData.append('moneda_id', model.currencyId.toString());
-    formData.append('precio_compra_base', model.basePurchasePrice.toString());
-    formData.append('precio_venta_base', model.baseSalePrice.toString());
+    ProductMapper.appendIfPresent(formData, 'descripcion', model.description);
+    ProductMapper.appendIfPresent(formData, 'unidad_id', model.unitId);
+    ProductMapper.appendIfPresent(formData, 'codigo_interno', model.internalCode);
+    ProductMapper.appendIfPresent(formData, 'codigo_fabricante', model.manufacturerCode);
+    ProductMapper.appendIfPresent(formData, 'peso', model.weight);
+    ProductMapper.appendIfPresent(formData, 'sucursal_id', model.branchId);
+    ProductMapper.appendIfPresent(formData, 'moneda_id', model.currencyId);
+    ProductMapper.appendIfPresent(formData, 'precio_compra_base', model.basePurchasePrice);
+    ProductMapper.appendIfPresent(formData, 'precio_venta_base', model.baseSalePrice);
 
     if (model.branches && model.branches.length > 0) {
       model.branches.forEach((branch, index) => {
@@ -152,5 +152,16 @@ export class ProductMapper {
     }
 
     return formData;
+  }
+
+  // categoryId/brandId/unitId/weight/branchId/currencyId/description/codes/prices are all
+  // nullable per StoreProductoRequest/UpdateProductoRequest -- calling .toString() on them
+  // unconditionally crashed with "can't access property toString, x is null" the moment a user
+  // left any of them empty (e.g. no brand selected).
+  private static appendIfPresent(formData: FormData, key: string, value: unknown): void {
+    if (value === null || value === undefined || value === '') {
+      return;
+    }
+    formData.append(key, String(value));
   }
 }

--- a/src/app/products/helpers/index.ts
+++ b/src/app/products/helpers/index.ts
@@ -3,4 +3,5 @@ export * from './map-filter-params';
 export * from './build-filter-form';
 export * from './product-structure'
 export * from './build-product-form';
+export * from './product-messages-error';
 

--- a/src/app/products/helpers/product-messages-error.ts
+++ b/src/app/products/helpers/product-messages-error.ts
@@ -1,0 +1,13 @@
+export const messages = {
+  name: {
+    required: 'El nombre es obligatorio',
+  },
+  basePurchasePrice: {
+    required: 'El precio de compra es obligatorio',
+    min: 'El precio de compra no puede ser negativo',
+  },
+  baseSalePrice: {
+    required: 'El precio de venta es obligatorio',
+    min: 'El precio de venta no puede ser negativo',
+  },
+};

--- a/src/app/products/helpers/product-structure.ts
+++ b/src/app/products/helpers/product-structure.ts
@@ -94,6 +94,12 @@ export const productStructure = (
       col: '6',
     },
     {
+      label: 'Peso',
+      formControlName: 'weight',
+      type: 'number',
+      col: '6',
+    },
+    {
       label: 'Imagen',
       formControlName: 'image',
       type: 'file',


### PR DESCRIPTION
…r, inline validation

Products form:
- weight (peso) existed in ProductForm/buildProductForm but was missing from productStructure(), so there was no input for it at all.
- product.mapper.ts called .toString() unconditionally on every nullable field (brandId, categoryId, unitId, weight, branchId, currencyId) when building the multipart FormData -- crashed with "can't access property toString, x is null" the moment any of them was left empty, even though the backend validates all of them as nullable. Added a guarded appendIfPresent() helper instead.
- The invalid-form path only showed a generic toast ("complete todos los campos requeridos") with no indication of which field. Added the same is-invalid + app-validation-messages pattern already used by Quotation, with product-messages-error.ts covering name/basePurchasePrice/ baseSalePrice (the only fields that actually have validators).

Almacen:
- toApiCreate() still sent suc_id, but AlmacenController::store() now validates sucursal_id (today's earlier fix) -- creating a warehouse broke with "The sucursal id field is required." the moment that backend fix shipped, since the frontend was never updated to match.

Verified against the running dev server: product saves fine with no brand selected, weight field renders, invalid fields highlight in red with their message, warehouse creation works with sucursal_id.