### PR TITLE
fix(supplier): email and address are optional, matching the backend

### DIFF
--- a/src/app/supplier/helpers/build-supplier-form.ts
+++ b/src/app/supplier/helpers/build-supplier-form.ts
@@ -12,11 +12,8 @@ export const buildSupplierForm = (): {
       null,
       Validators.compose([Validators.required, Validators.minLength(3)]),
     ),
-    email: new FormControl(null, Validators.compose([Validators.required, Validators.email])),
-    address: new FormControl(
-      null,
-      Validators.compose([Validators.required, Validators.minLength(3)]),
-    ),
+    email: new FormControl(null, Validators.email),
+    address: new FormControl(null, Validators.minLength(3)),
     documentTypeId: new FormControl(null, Validators.required),
     document: new FormControl(null, Validators.required),
     phone: new FormControl(null),


### PR DESCRIPTION
ProveedorController validates email and direccion as nullable (only tipoDocumentoId and nombre are required). The frontend form required both unconditionally. document/documentTypeId stay required per product decision, same call already made for Cliente's document field.

email keeps Validators.email so format is still checked once typed; address keeps Validators.minLength(3) for the same reason.

Verified: e2e/master-data-generic.spec.ts's Proveedor case still passes, and a supplier with only name/document/documentType saves successfully against the running dev server.