### PR TITLE
feat(products): bulk import from Excel with Kardex-audited stock

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -79,6 +79,14 @@ export const routes: Routes = [
         },
       },
       {
+        path: 'productos/importar',
+        loadComponent: () =>
+          import('./products/pages/product-import/product-import').then((m) => m.ProductImport),
+        data: {
+          title: 'Importar productos',
+        },
+      },
+      {
         path: 'sucursales',
         loadComponent: () => import('./sucursal/pages/sucursal/sucursal').then((m) => m.SucursalPage),
         data: {

--- a/src/app/products/core/models/product-import.model.ts
+++ b/src/app/products/core/models/product-import.model.ts
@@ -1,0 +1,38 @@
+export interface ProductImportRow {
+  fila: number;
+  codigo_interno: string | null;
+  nombre: string | null;
+  categoria: string | null;
+  unidad: string | null;
+  precio_compra: number | null;
+  precio_venta: number | null;
+  peso: number | null;
+  stock_inicial: number | null;
+  valida: boolean;
+  errores: string[];
+  categoria_se_creara: boolean;
+  unidad_se_creara: boolean;
+}
+
+export interface ProductImportPreview {
+  filas: ProductImportRow[];
+  total_filas: number;
+  total_validas: number;
+  total_con_error: number;
+  categorias_a_crear: string[];
+  unidades_a_crear: string[];
+}
+
+export interface ProductImportRowResult {
+  fila: number;
+  exito: boolean;
+  nombre: string | null;
+  producto_id: number | null;
+  error: string | null;
+}
+
+export interface ProductImportConfirmResult {
+  resultados: ProductImportRowResult[];
+  total_creados: number;
+  total_con_error: number;
+}

--- a/src/app/products/core/services/product-import.service.ts
+++ b/src/app/products/core/services/product-import.service.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { BaseService } from '../../../shared/services/base.service';
+import { ResponseDto } from '../../../shared/models/api/response.dto';
+import { environment } from '../../../../environments/environment';
+import { ProductImportConfirmResult, ProductImportPreview } from '../models/product-import.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProductImportService extends BaseService {
+  constructor(http: HttpClient) {
+    super(http, `${environment.apiUrl}/productos/import`);
+  }
+
+  downloadTemplate(): void {
+    this.getRequestFile('/plantilla', 'plantilla-importacion-productos.xlsx');
+  }
+
+  preview(archivo: File): Observable<ResponseDto<ProductImportPreview>> {
+    const formData = new FormData();
+    formData.append('archivo', archivo);
+    return this.postRequestForm<ResponseDto<ProductImportPreview>>('/preview', formData);
+  }
+
+  confirmar(archivo: File, almacenId: number): Observable<ResponseDto<ProductImportConfirmResult>> {
+    const formData = new FormData();
+    formData.append('archivo', archivo);
+    formData.append('almacen_id', String(almacenId));
+    return this.postRequestForm<ResponseDto<ProductImportConfirmResult>>('/confirmar', formData);
+  }
+}

--- a/src/app/products/pages/product-import/product-import.html
+++ b/src/app/products/pages/product-import/product-import.html
@@ -1,0 +1,181 @@
+<c-row class="mb-3">
+  <c-col>
+    <h4>Importar productos desde Excel</h4>
+    <p class="text-medium-emphasis">
+      Cargá un catálogo en lote sin perder el control de Kardex: cada producto se crea con los
+      mismos casos de uso del alta manual, y el stock inicial queda registrado como un movimiento
+      de ingreso auditable.
+    </p>
+  </c-col>
+  <c-col class="text-end">
+    <a routerLink="/productos" cButton color="secondary">Volver a Productos</a>
+  </c-col>
+</c-row>
+
+<c-card class="mb-3">
+  <c-card-body>
+    <c-row class="g-3 align-items-end">
+      <c-col sm="12" md="4">
+        <button cButton color="secondary" (click)="descargarPlantilla()">
+          <svg cIcon name="cilCloudDownload"></svg>
+          Descargar plantilla
+        </button>
+      </c-col>
+
+      <c-col sm="12" md="4">
+        <label for="archivo">Archivo (.xlsx, .xls, .csv)</label>
+        <input
+          id="archivo"
+          type="file"
+          class="form-control"
+          accept=".xlsx,.xls,.csv"
+          (change)="onArchivoSeleccionado($event)"
+        />
+      </c-col>
+
+      <c-col sm="12" md="4">
+        <button
+          cButton
+          color="primary"
+          [disabled]="!archivoSeleccionado || cargandoPreview"
+          (click)="verVistaPrevia()"
+        >
+          <svg cIcon name="cilSearch"></svg>
+          {{ cargandoPreview ? 'Analizando...' : 'Vista previa' }}
+        </button>
+      </c-col>
+    </c-row>
+  </c-card-body>
+</c-card>
+
+@if (preview) {
+<c-card class="mb-3">
+  <c-card-body>
+    <c-row class="mb-3">
+      <c-col sm="12" md="3"><strong>Total filas:</strong> {{ preview.total_filas }}</c-col>
+      <c-col sm="12" md="3" class="text-success"
+        ><strong>Válidas:</strong> {{ preview.total_validas }}</c-col
+      >
+      <c-col sm="12" md="3" class="text-danger"
+        ><strong>Con error:</strong> {{ preview.total_con_error }}</c-col
+      >
+    </c-row>
+
+    @if (preview.categorias_a_crear.length > 0) {
+    <p>
+      <strong>Categorías nuevas que se crearán:</strong>
+      {{ preview.categorias_a_crear.join(', ') }}
+    </p>
+    } @if (preview.unidades_a_crear.length > 0) {
+    <p>
+      <strong>Unidades nuevas que se crearán:</strong>
+      {{ preview.unidades_a_crear.join(', ') }}
+    </p>
+    }
+
+    <div class="table-responsive">
+      <table cTable striped small>
+        <thead>
+          <tr>
+            <th>Fila</th>
+            <th>Código</th>
+            <th>Nombre</th>
+            <th>Categoría</th>
+            <th>Unidad</th>
+            <th>Stock inicial</th>
+            <th>Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (fila of preview.filas; track fila.fila) {
+          <tr [class.table-danger]="!fila.valida">
+            <td>{{ fila.fila }}</td>
+            <td>{{ fila.codigo_interno || '—' }}</td>
+            <td>{{ fila.nombre || '—' }}</td>
+            <td>{{ fila.categoria || '—' }}</td>
+            <td>{{ fila.unidad || '—' }}</td>
+            <td>{{ fila.stock_inicial ?? 0 }}</td>
+            <td>
+              @if (fila.valida) {
+              <span class="text-success">Válida</span>
+              } @else {
+              <span class="text-danger">{{ fila.errores.join('; ') }}</span>
+              }
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+
+    <c-row class="g-3 align-items-end mt-2">
+      <c-col sm="12" md="4">
+        <label for="almacenDestino">Almacén destino para el stock inicial</label>
+        <select
+          id="almacenDestino"
+          class="form-control form-select"
+          [(ngModel)]="almacenDestinoId"
+          [ngModelOptions]="{ standalone: true }"
+        >
+          <option [ngValue]="null">Seleccioná un almacén</option>
+          @for (almacen of almacenes; track almacen.id) {
+          <option [ngValue]="almacen.id">{{ almacen.nombre }}</option>
+          }
+        </select>
+      </c-col>
+      <c-col sm="12" md="4">
+        <button
+          cButton
+          color="success"
+          [disabled]="
+            !almacenDestinoId || preview.total_validas === 0 || cargandoConfirmacion
+          "
+          (click)="confirmarImportacion()"
+        >
+          <svg cIcon name="cilCheckCircle"></svg>
+          {{ cargandoConfirmacion ? 'Importando...' : 'Confirmar importación' }}
+        </button>
+      </c-col>
+    </c-row>
+  </c-card-body>
+</c-card>
+}
+
+@if (resultado) {
+<c-card>
+  <c-card-body>
+    <h5>Resultado de la importación</h5>
+    <p>
+      <span class="text-success">{{ resultado.total_creados }} creados</span> ·
+      <span class="text-danger">{{ resultado.total_con_error }} con error</span>
+    </p>
+
+    <div class="table-responsive">
+      <table cTable striped small>
+        <thead>
+          <tr>
+            <th>Fila</th>
+            <th>Nombre</th>
+            <th>Resultado</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (item of resultado.resultados; track item.fila) {
+          <tr [class.table-danger]="!item.exito">
+            <td>{{ item.fila }}</td>
+            <td>{{ item.nombre || '—' }}</td>
+            <td>
+              @if (item.exito) {
+              <span class="text-success">Creado (#{{ item.producto_id }})</span>
+              } @else {
+              <span class="text-danger">{{ item.error }}</span>
+              }
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  </c-card-body>
+</c-card>
+}

--- a/src/app/products/pages/product-import/product-import.ts
+++ b/src/app/products/pages/product-import/product-import.ts
@@ -1,0 +1,129 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import {
+  ButtonDirective,
+  CardBodyComponent,
+  CardComponent,
+  ColComponent,
+  RowComponent,
+  TableDirective,
+} from '@coreui/angular';
+import { IconDirective } from '@coreui/icons-angular';
+import { GlobalNotification } from '@shared/alerts/global-notification/global-notification';
+import { AlmacenService } from '../../../almacen/core/services/almacen.service';
+import { GetAlmacenModel } from '../../../almacen/core/models';
+import { ProductImportService } from '../../core/services/product-import.service';
+import {
+  ProductImportConfirmResult,
+  ProductImportPreview,
+} from '../../core/models/product-import.model';
+
+@Component({
+  selector: 'app-product-import',
+  imports: [
+    RouterLink,
+    FormsModule,
+    RowComponent,
+    ColComponent,
+    CardComponent,
+    CardBodyComponent,
+    IconDirective,
+    ButtonDirective,
+    TableDirective,
+  ],
+  templateUrl: './product-import.html',
+  styleUrl: './product-import.scss',
+})
+export class ProductImport implements OnInit {
+  readonly #productImportService = inject(ProductImportService);
+  readonly #almacenService = inject(AlmacenService);
+  readonly #globalNotification = inject(GlobalNotification);
+
+  public almacenes: GetAlmacenModel[] = [];
+  public almacenDestinoId: number | null = null;
+
+  public archivoSeleccionado: File | null = null;
+  public cargandoPreview = false;
+  public cargandoConfirmacion = false;
+
+  public preview: ProductImportPreview | null = null;
+  public resultado: ProductImportConfirmResult | null = null;
+
+  ngOnInit(): void {
+    this.#almacenService.getAll().subscribe({
+      next: (response) => (this.almacenes = response.data),
+      error: () =>
+        this.#globalNotification.openToastAlert(
+          'Error',
+          'No se pudieron cargar los almacenes',
+          'danger',
+        ),
+    });
+  }
+
+  descargarPlantilla(): void {
+    this.#productImportService.downloadTemplate();
+  }
+
+  onArchivoSeleccionado(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.archivoSeleccionado = input.files?.[0] ?? null;
+    this.preview = null;
+    this.resultado = null;
+  }
+
+  verVistaPrevia(): void {
+    if (!this.archivoSeleccionado) {
+      return;
+    }
+
+    this.cargandoPreview = true;
+    this.resultado = null;
+
+    this.#productImportService.preview(this.archivoSeleccionado).subscribe({
+      next: (response) => {
+        this.preview = response.data;
+        this.cargandoPreview = false;
+      },
+      error: (error) => {
+        this.cargandoPreview = false;
+        this.#globalNotification.openToastAlert(
+          'Error',
+          error?.error?.messages?.[0]?.message ?? 'No se pudo leer el archivo',
+          'danger',
+        );
+      },
+    });
+  }
+
+  confirmarImportacion(): void {
+    if (!this.archivoSeleccionado || !this.almacenDestinoId) {
+      return;
+    }
+
+    this.cargandoConfirmacion = true;
+
+    this.#productImportService
+      .confirmar(this.archivoSeleccionado, this.almacenDestinoId)
+      .subscribe({
+        next: (response) => {
+          this.resultado = response.data;
+          this.cargandoConfirmacion = false;
+          this.#globalNotification.openToastAlert(
+            'Importación procesada',
+            `${response.data.total_creados} productos creados, ${response.data.total_con_error} con error`,
+            response.data.total_con_error > 0 ? 'warning' : 'success',
+          );
+        },
+        error: (error) => {
+          this.cargandoConfirmacion = false;
+          this.#globalNotification.openToastAlert(
+            'Error',
+            error?.error?.messages?.[0]?.message ?? 'No se pudo procesar la importación',
+            'danger',
+          );
+        },
+      });
+  }
+}

--- a/src/app/products/pages/products/products.html
+++ b/src/app/products/pages/products/products.html
@@ -3,6 +3,10 @@
         <h4>{{ title }}</h4>
     </c-col>
     <c-col class="text-end">
+        <a routerLink="/productos/importar" cButton color="secondary" class="me-2">
+            <svg cIcon name="cilCloudUpload"></svg>
+            Importar desde Excel
+        </a>
         <button cButton color="primary" (click)="openModal()">
             <svg cIcon name="cilPlus"></svg>
             Nuevo Registro

--- a/src/app/products/pages/products/products.ts
+++ b/src/app/products/pages/products/products.ts
@@ -1,4 +1,5 @@
 import { Component, Inject, inject, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import {
   ButtonDirective,
   CardBodyComponent,
@@ -29,6 +30,7 @@ import { ConfirmService } from '@shared/confirm-modal/core/services/confirm-moda
 @Component({
   selector: 'app-products',
   imports: [
+    RouterLink,
     RowComponent,
     ColComponent,
     CardComponent,


### PR DESCRIPTION
New /productos/importar screen: download a template, upload it, review a per-row preview (validation errors, which categories/units will be auto-created) before confirming, pick the target warehouse for initial stock, then confirm. Mirrors the backend flow which reuses the same use cases as manual product creation -- initial stock lands as a real Kardex entry, not a direct DB write.