### PR TITLE
fix(products): show manufacturer code and description in import preview

### DIFF
--- a/src/app/products/core/models/product-import.model.ts
+++ b/src/app/products/core/models/product-import.model.ts
@@ -1,7 +1,9 @@
 export interface ProductImportRow {
   fila: number;
   codigo_interno: string | null;
+  codigo_fabricante: string | null;
   nombre: string | null;
+  descripcion: string | null;
   categoria: string | null;
   unidad: string | null;
   precio_compra: number | null;

--- a/src/app/products/pages/product-import/product-import.html
+++ b/src/app/products/pages/product-import/product-import.html
@@ -79,7 +79,9 @@
           <tr>
             <th>Fila</th>
             <th>Código</th>
+            <th>Cód. fabricante</th>
             <th>Nombre</th>
+            <th>Descripción</th>
             <th>Categoría</th>
             <th>Unidad</th>
             <th>Stock inicial</th>
@@ -91,7 +93,9 @@
           <tr [class.table-danger]="!fila.valida">
             <td>{{ fila.fila }}</td>
             <td>{{ fila.codigo_interno || '—' }}</td>
+            <td>{{ fila.codigo_fabricante || '—' }}</td>
             <td>{{ fila.nombre || '—' }}</td>
+            <td>{{ fila.descripcion || '—' }}</td>
             <td>{{ fila.categoria || '—' }}</td>
             <td>{{ fila.unidad || '—' }}</td>
             <td>{{ fila.stock_inicial ?? 0 }}</td>


### PR DESCRIPTION
Complements the backend fix that now persists both fields during the bulk Excel import.